### PR TITLE
Show Password feature implemented

### DIFF
--- a/senz-web/frontend/src/components/authentication/Register.js
+++ b/senz-web/frontend/src/components/authentication/Register.js
@@ -12,6 +12,8 @@ import {
 import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
 import IconButton from '@material-ui/core/IconButton';
 import InfoIcon from '@material-ui/icons/Info';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import VisibilityIcon from '@material-ui/icons/Visibility';
 
 import { Field, reduxForm } from "redux-form";
 import { withStyles } from "@material-ui/core/styles";
@@ -44,6 +46,19 @@ const styles = theme => ({
 });
 
 class Register extends Component {
+
+  state = {
+    type: 'password',
+    Icon: <VisibilityOffIcon/>
+  }
+
+
+  handleClick = () => this.setState(({type}) => ({
+    Icon: type === 'text' ? <VisibilityOffIcon/> : <VisibilityIcon/> ,
+    type: type === 'text' ? 'password' : 'text'
+    
+  }))
+
   renderInputError = ({ error, touched }) => {
     if (error && touched) return { error: true, message: error };
     else return { error: false, message: "" };
@@ -132,15 +147,18 @@ class Register extends Component {
                   type="text"
                 />
               </Grid>
-              <Grid item xs={10}>
+              <Grid item xs={8}>
                 <Field
                   name="password"
                   id="password"
                   label="Password"
-                  type="password"
+                  type={this.state.type}
                   component={this.renderInput}
                 />
               </Grid>
+              <IconButton aria-label="info" onClick = {this.handleClick}>
+                  {this.state.Icon}
+              </IconButton>
               <IconButton aria-label="info" onClick = {this.passwordCheckHandler}>
                 <InfoIcon/>
               </IconButton>


### PR DESCRIPTION
Fixes #131 

Standard show password feature has been implemented. When the eye button is clicked, it shows the password at any stage and the icon is changed from close eye to open eye and vice versa.
By default password is hidden and icon is set to closed eye.

All tests has been passed : 
![11](https://user-images.githubusercontent.com/39923784/75179080-518e2080-575f-11ea-9d32-a14f1e9cbd1e.JPG)

Screenshots has been attached here :
1- When eye button is not clicked : 
![8](https://user-images.githubusercontent.com/39923784/75178846-e3e1f480-575e-11ea-91a2-61a5cc3d257d.JPG)

2- When eye button is clicked :
![9](https://user-images.githubusercontent.com/39923784/75178953-112ea280-575f-11ea-8e2b-9a84be2f8b77.JPG)

![10](https://user-images.githubusercontent.com/39923784/75178963-17bd1a00-575f-11ea-9827-befcd839f742.JPG)
