### PR TITLE
Show password feature in login page is implemented

### DIFF
--- a/senz-web/frontend/src/components/authentication/Login.js
+++ b/senz-web/frontend/src/components/authentication/Login.js
@@ -9,6 +9,9 @@ import {
   Avatar
 } from "@material-ui/core";
 import LockOutlinedIcon from "@material-ui/icons/LockOutlined";
+import IconButton from '@material-ui/core/IconButton';
+import VisibilityOffIcon from '@material-ui/icons/VisibilityOff';
+import VisibilityIcon from '@material-ui/icons/Visibility';
 
 import { Field, reduxForm } from "redux-form";
 import { withStyles } from "@material-ui/core/styles";
@@ -41,6 +44,18 @@ const styles = theme => ({
 });
 
 class Register extends Component {
+
+  state = {
+    type: 'password',
+    Icon: <VisibilityOffIcon/>
+  }
+
+  handleClick = () => this.setState(({type}) => ({
+    Icon: type === 'text' ? <VisibilityOffIcon/> : <VisibilityIcon/> ,
+    type: type === 'text' ? 'password' : 'text'
+    
+  }))
+
   renderInputError = ({ error, touched }) => {
     if (error && touched) return { error: true, message: error };
     else return { error: false, message: "" };
@@ -80,7 +95,7 @@ class Register extends Component {
     this.props.LoginAction({ email, password }, this.props.history);
   };
   render() {
-    const { classes } = this.props;
+    const { classes} = this.props;
     return (
       <Container component="main" maxWidth="xs" data-test="LoginComponent">
         <CssBaseline />
@@ -106,15 +121,18 @@ class Register extends Component {
                   type="text"
                 />
               </Grid>
-              <Grid item xs={12}>
+              <Grid item xs={10}>
                 <Field
                   name="password"
                   id="password"
                   label="Password"
-                  type="password"
+                  type={this.state.type}
                   component={this.renderInput}
                 />
               </Grid>
+              <IconButton aria-label="info" onClick = {this.handleClick}>
+                  {this.state.Icon}
+              </IconButton>
             </Grid>
             <Button
               type="submit"


### PR DESCRIPTION
Fixes #136 

A show password feature is implemented in login page which enables user to view the password which will help them to write the password correctly.
Sometime users forget what they have written, so they write the password from the beginning, but if they have this feature then they can see the password at any instant of the typing, which will assist them in writing the password correctly.
All the tests has been passed successfully : 
![14](https://user-images.githubusercontent.com/39923784/75181246-d4b17580-5763-11ea-8841-7e6eeb7901a0.JPG)


Screenshots has been attached to show the changes : 
1- When eye icon(cross/closed eye) is not clicked password is hidden : 
![12](https://user-images.githubusercontent.com/39923784/75181137-a03db980-5763-11ea-90f7-ef07be2c396b.JPG)

2- When eye icon is clicked password is shown : 
![13](https://user-images.githubusercontent.com/39923784/75181205-bba8c480-5763-11ea-860c-df9093c34a32.JPG)

