### PR TITLE
removed password validation from login page

### DIFF
--- a/senz-web/frontend/src/components/authentication/Login.js
+++ b/senz-web/frontend/src/components/authentication/Login.js
@@ -139,15 +139,9 @@ const emailValid = email => {
   return pattern.test(email);
 };
 
-const passwordValid = password => {
-  if (password === undefined) return false;
-  return password.length > 4;
-};
-
 const validate = ({ firstName, lastName, email, password, cPassword }) => {
   const errors = {};
   if (!emailValid(email)) errors.email = "Email not valid";
-  if (!passwordValid(password)) errors.password = "Password too short";
   return errors;
 };
 


### PR DESCRIPTION
Fixes #139   

Few lines of code has been removed basically from the code base to ensure that password validation i.e whether password satisfies the minimum condition or not is not checked at the time of login .

All tests has been passed:
![18](https://user-images.githubusercontent.com/39923784/75193801-eeab8200-577c-11ea-8394-2ded8b65beab.JPG)

Screenshots: 
Earlier it looks like this : 

![16](https://user-images.githubusercontent.com/39923784/75193554-7f359280-577c-11ea-8b1c-0fce834c3faf.JPG)
![17](https://user-images.githubusercontent.com/39923784/75193562-8361b000-577c-11ea-9d5e-42a01812413c.JPG)


Now it looks like this after modification : 
![15](https://user-images.githubusercontent.com/39923784/75193605-91afcc00-577c-11ea-86b7-b794c3ead756.JPG)

In this image we can see the snackbar type thing which inform us to fill that field.
![WhatsApp Image 2020-02-25 at 02 48 08](https://user-images.githubusercontent.com/39923784/75193649-a9875000-577c-11ea-9d66-aad88680b083.jpeg)
