### PR TITLE
fixed password view and show confirm password

### DIFF
--- a/senz-web/frontend/src/components/authentication/Register.js
+++ b/senz-web/frontend/src/components/authentication/Register.js
@@ -49,16 +49,24 @@ class Register extends Component {
 
   state = {
     type: 'password',
-    Icon: <VisibilityOffIcon/>
+    Icon: <VisibilityIcon/>,
+    cType: 'password',
+    cIcon: <VisibilityIcon/>
   }
 
 
   handleClick = () => this.setState(({type}) => ({
-    Icon: type === 'text' ? <VisibilityOffIcon/> : <VisibilityIcon/> ,
+    Icon: type === 'text' ? <VisibilityIcon/> : <VisibilityOffIcon/> ,
     type: type === 'text' ? 'password' : 'text'
     
   }))
 
+  confirmPassowrdShow = () => this.setState(({cType}) => ({
+    cIcon: cType === 'text' ? <VisibilityIcon/> : <VisibilityOffIcon/> ,
+    cType: cType === 'text' ? 'password' : 'text'
+    
+  }))
+  
   renderInputError = ({ error, touched }) => {
     if (error && touched) return { error: true, message: error };
     else return { error: false, message: "" };
@@ -162,15 +170,18 @@ class Register extends Component {
               <IconButton aria-label="info" onClick = {this.passwordCheckHandler}>
                 <InfoIcon/>
               </IconButton>
-              <Grid item xs={12}>
+              <Grid item xs={10}>
                 <Field
                   name="cPassword"
                   id="cPassword"
                   label="Confirm Password"
-                  type="password"
+                  type={this.state.cType}
                   component={this.renderInput}
                 />
               </Grid>
+              <IconButton aria-label="info" onClick = {this.confirmPassowrdShow}>
+                  {this.state.cIcon}
+              </IconButton>
             </Grid>
             <Button
               type="submit"
@@ -191,7 +202,7 @@ class Register extends Component {
             </Grid>
           </form>
         </div>
-      </Container >
+      </Container>
     );
   }
 }


### PR DESCRIPTION
Fixes #148 
Few changes from the PR #135 . In that show password was only applied to password section , now it has been applied to confirm password also and now the eye-icon will be open when password is hidden and crossed when password is not hidden. 
Show confirm password feature has been implemented.

Screenshots of the same has been attached : 
Earlier it was like this : 
![26](https://user-images.githubusercontent.com/39923784/75652002-ffc62880-5c7f-11ea-9884-f942af4dadbc.JPG)

Now it looks like this : 
![25](https://user-images.githubusercontent.com/39923784/75652005-02c11900-5c80-11ea-9342-c47089658774.JPG)

Show Password : 
![27](https://user-images.githubusercontent.com/39923784/75652138-529fe000-5c80-11ea-9254-06c1ce88ddbb.JPG)

Show confirm Password : 

![28](https://user-images.githubusercontent.com/39923784/75652215-82e77e80-5c80-11ea-8506-a2ba55c84cbf.JPG)
